### PR TITLE
fix: Quoting of keybding var

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ After the package is loaded, you can call `mu4e-views-mu4e-select-view-msg-metho
 You may want to bind this to a key in `mu4e-headers-mode-map`.
 
 ~~~elisp
-(define-key mu4e-headers-mode-map (kbd "v") mu4e-views-mu4e-select-view-msg-method)
+(define-key mu4e-headers-mode-map (kbd "v") 'mu4e-views-mu4e-select-view-msg-method)
 ~~~
 
 Here is an example setup:


### PR DESCRIPTION
Hi @lordpretzel 

Thank you very much for this interesting library! As a prolific mu4e user, I'm very much intrigued! Just recently, I've written a blog post on how to use [mu4e with HTML mails](https://200ok.ch/posts/2020-05-27_using_emacs_and_mu4e_for_emails_even_with_html.html) - but your project is going to make that obsolete, real soon^^

I just compiled Emacs 27.1 with xwidgets support to test. And it does work! Having said that, I'm not going to use it, because xwidgets is flickering flickering a lot - and it seems that it upsets my otherwise very stable Emacs. But I'll happily keep track of the progress in this repo and of xwidgets and will come back to the future.

Ok, on to the rationale of this PR: It fixes `Debugger entered--Lisp error: (void-variable mu4e-views-mu4e-select-view-msg-method)`.

Thank you for your effort and all the best!🙏
