### PR TITLE
Resolve "No buffer named *Article*" during rendering HTML email

### DIFF
--- a/Eldev
+++ b/Eldev
@@ -13,4 +13,5 @@
 
 ;; do not include the test config for docker tests
 (setq eldev-standard-excludes
-      (append eldev-standard-excludes '("./testconfig/**")))
+      `(:or ,eldev-standard-excludes "./testconfig/**"))
+;; (pp eldev-standard-excludes)

--- a/build-docker-images.sh
+++ b/build-docker-images.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-docker build -t mu4e-views-test-gui -f Dockerfile-gui .
-docker build -t mu4e-views-test -f Dockerfile .
+docker build -t mu4e-views-test-gui --platform linux/amd64 -f Dockerfile-gui .
+#docker build -t mu4e-views-test -f Dockerfile .

--- a/dockerfiles/build-new-mu.sh
+++ b/dockerfiles/build-new-mu.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSIONS="v1.8.14 v1.10.1 master" # v1.10.1" # v1.8.14 v1.10.1 master"
+VERSIONS="v1.8.14 v1.10.1 v1.12.2 master" # v1.10.1" # v1.8.14 v1.10.1 master"
 cd /mu-src
 
 check_exit()

--- a/mu4e-views.el
+++ b/mu4e-views.el
@@ -1824,7 +1824,7 @@ view buffers."
                 gnus-article-buffer (plist-get msg :gnus-buffer))
           (gnus-article-browse-html-parts parts header)
           ;; reset to original value
-          (setq gnus-article-buffer tmp-gnus-buffer)))))
+          (setq gnus-article-buffer tmp-gnus-buffer))))))
 
 (defun mu4e-views--extract-text-and-html-coding-from-gnus (parts msg inmp)
   "Extract text parts from PARTS of message MSG."

--- a/mu4e-views.el
+++ b/mu4e-views.el
@@ -2792,6 +2792,8 @@ replace with."
   (when (mu4e-views-mu4e-ver-> '(1 7))
     (advice-add 'mu4e-compose
                 :override #'mu4e-views-compose))
+  (when (mu4e-views-mu4e-ver->= '(1 12))
+    (defvaralias 'mu4e~view-link-map 'mu4e--view-link-map))
   (setq mu4e-views--advice-installed t))
 
 (unless mu4e-views--advice-installed

--- a/mu4e-views.el
+++ b/mu4e-views.el
@@ -1819,7 +1819,12 @@ view buffers."
             header)
         (with-current-buffer gnusbuf
           (mu4e-views--extract-text-and-html-coding-from-gnus parts msg nil)
-          (gnus-article-browse-html-parts parts header))))))
+          ;; necessary to avoid (error "No buffer named *Article*")
+          (setq tmp-gnus-buffer gnus-article-buffer
+                gnus-article-buffer (plist-get msg :gnus-buffer))
+          (gnus-article-browse-html-parts parts header)
+          ;; reset to original value
+          (setq gnus-article-buffer tmp-gnus-buffer)))))
 
 (defun mu4e-views--extract-text-and-html-coding-from-gnus (parts msg inmp)
   "Extract text parts from PARTS of message MSG."


### PR DESCRIPTION
For certain HTML emails, gnus seems to require the view buffer
named as `gnus-article-buffer`, otherwise it provides an
`(error "No buffer named *Article*")`.

This patch temporarily changes the value of `gnus-article-buffer`
to the one used by mu4e-views, only during the call to `gnus-article-
browse-html-parts`.